### PR TITLE
Don't blow up loading an empty YAML file when 'optional: true'

### DIFF
--- a/lib/chalk-config.rb
+++ b/lib/chalk-config.rb
@@ -289,7 +289,7 @@ class Chalk::Config
     end
     if loaded.is_a?(FalseClass)
       raise EmptyYamlFileError.new("YAML.load(#{filepath.inspect}) parses false, which indicates that the file is empty.")
-    elsif loaded.is_a?(Hash)
+    elsif not loaded.is_a?(Hash)
       raise Error.new("YAML.load(#{filepath.inspect}) parses into a #{loaded.class}, not a Hash")
     end
     loaded

--- a/lib/chalk-config/errors.rb
+++ b/lib/chalk-config/errors.rb
@@ -5,4 +5,6 @@ class Chalk::Config
   class MissingEnvironment < Error; end
   # Thrown from environment assertions.
   class DisallowedEnvironment < Error; end
+  # Thrown if a YAML file parses empty (mixture of empty lines and comments)
+  class EmptyYamlFileError < Error; end
 end

--- a/test/functional/general.rb
+++ b/test/functional/general.rb
@@ -53,8 +53,9 @@ class Critic::Functional::GeneralTest < Critic::Functional::Test
 
   describe 'empty yaml file' do
     it 'Emits a warning when optional = true' do
-      assert_output(stdout = "WARN: YAML.load(\"/Users/areitz/stripe/chalk-config/test/functional/general/empty.yaml\") parses false, which indicates that the file is empty. Continuing.\n") do
-        Chalk::Config.register(File.expand_path('../general/empty.yaml', __FILE__), optional: true)
+      file_path = File.expand_path('../general/empty.yaml', __FILE__)
+      assert_output(stdout = "WARN: YAML.load(\"#{file_path}\") parses false, which indicates that the file is empty. Continuing.\n") do
+        Chalk::Config.register(file_path, optional: true)
       end
     end
 

--- a/test/functional/general.rb
+++ b/test/functional/general.rb
@@ -51,6 +51,20 @@ class Critic::Functional::GeneralTest < Critic::Functional::Test
     end
   end
 
+  describe 'empty yaml file' do
+    it 'Emits a warning when optional = true' do
+      assert_output(stdout = "WARN: YAML.load(\"/Users/areitz/stripe/chalk-config/test/functional/general/empty.yaml\") parses false, which indicates that the file is empty. Continuing.\n") do
+        Chalk::Config.register(File.expand_path('../general/empty.yaml', __FILE__), optional: true)
+      end
+    end
+
+    it 'raises an exception when optional = false' do
+      assert_raises(Chalk::Config::EmptyYamlFileError) do
+        Chalk::Config.register(File.expand_path('../general/empty.yaml', __FILE__), optional: false)
+      end
+    end
+  end
+
   describe 'missing nested files' do
     it 'does not create the relevant config key' do
       Chalk::Config.register(File.expand_path('../general/nonexistent.yaml', __FILE__),

--- a/test/functional/general/empty.yaml
+++ b/test/functional/general/empty.yaml
@@ -1,0 +1,3 @@
+#
+# This is a valid YAML file, but it doesn't actually have any data to load.
+#


### PR DESCRIPTION
r? @nelhage, @dylanvee 

Per T17194, don't fail with a strange error message if loading an empty YAML file. With `optional: false`, give a nice error message. With `optional: true`, print a warning, and keep going.